### PR TITLE
ページバーで例外が出る

### DIFF
--- a/AccessoryView.m
+++ b/AccessoryView.m
@@ -267,6 +267,9 @@ NSRect COIntRect(NSRect aRect)
 			if (![controller readFromLeft]) {
 				temp = tempRect.size.width - temp-1;
 			}
+			if (temp < 0) {
+				temp = 0;
+			}
 			temp = temp/tempRect.size.width;
 			
 			float fPage = [(Controller *)controller pageCount]*temp;


### PR DESCRIPTION
ページバーの1ページ目付近にカーソルを合わせると配列のindexが-1となって例外が出ていました。
例外でページバーが停止していたので、例外が出ないように修正しました。