### PR TITLE
画像のDPIを無視する設定を追加

### DIFF
--- a/Base.lproj/MainMenu.xib
+++ b/Base.lproj/MainMenu.xib
@@ -1624,7 +1624,7 @@ go to the last page always.</string>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Advanced" identifier="" id="1607">
-                                <view key="view" ambiguous="YES" id="1608">
+                                <view key="view" id="1608">
                                     <rect key="frame" x="10" y="33" width="587" height="488"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
@@ -1714,7 +1714,7 @@ go to the last page always.</string>
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4255">
-                                            <rect key="frame" x="17" y="124" width="435" height="51"/>
+                                            <rect key="frame" x="17" y="97" width="435" height="51"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Change current folder when the currently open book was moved:" id="4313">
                                                 <font key="font" metaFont="system"/>
@@ -1723,7 +1723,7 @@ go to the last page always.</string>
                                             </textFieldCell>
                                         </textField>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3292">
-                                            <rect key="frame" x="14" y="187" width="174" height="32"/>
+                                            <rect key="frame" x="14" y="160" width="174" height="32"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="push" title="Disposing of settings" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4312">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1734,7 +1734,7 @@ go to the last page always.</string>
                                             </connections>
                                         </button>
                                         <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4256">
-                                            <rect key="frame" x="14" y="131" width="98" height="22"/>
+                                            <rect key="frame" x="14" y="104" width="98" height="22"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <popUpButtonCell key="cell" type="push" title="Ask" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="4260" id="4314">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -1844,6 +1844,14 @@ go to the last page always.</string>
                                             <rect key="frame" x="114" y="427" width="109" height="18"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="ym1-NJ-Ohp">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                        </button>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VGQ-cy-3zK">
+                                            <rect key="frame" x="17" y="242" width="151" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Ignore image DPI:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="uSp-vs-7XI">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
@@ -2935,6 +2943,7 @@ Gw
                 <outlet property="fitOriginalCheck" destination="1627" id="1689"/>
                 <outlet property="fontTextField" destination="2769" id="2772"/>
                 <outlet property="goToLastPopUpButton" destination="2908" id="2913"/>
+                <outlet property="ignoreDpiCheck" destination="VGQ-cy-3zK" id="ya7-06-Ao7"/>
                 <outlet property="imageCacheTextField" destination="2048" id="2090"/>
                 <outlet property="inputTabView" destination="2066" id="2923"/>
                 <outlet property="inputTableView" destination="1364" id="1691"/>

--- a/Controller.m
+++ b/Controller.m
@@ -74,6 +74,8 @@ static const int DIALOG_CANCEL	= 129;
 	
 	[appDefault setObject:[NSNumber numberWithInt:10] forKey:@"OpenRecentLimit"];
 	
+	[appDefault setObject:[NSNumber numberWithInt:NO] forKey:@"IgnoreImageDpi"];
+
 	[defaults registerDefaults:appDefault];
 	
 	fitScreenMode = 0;
@@ -276,6 +278,12 @@ static const int DIALOG_CANCEL	= 129;
 	} else {
 		[window setHideMenuBar:YES];
 	}
+
+	BOOL ignoreImageDpi = [defaults boolForKey:@"IgnoreImageDpi"];
+	[fullImageView setIgnoreImageDpi:ignoreImageDpi];
+	[imageView setIgnoreImageDpi:ignoreImageDpi];
+	[defaults setBool:ignoreImageDpi forKey:@"IgnoreImageDpi"];
+
 	[[NSNotificationCenter defaultCenter] addObserver:self 
 											 selector:@selector(viewDidEndLiveResize:) 
 												 name:@"ViewDidEndLiveResize"
@@ -1874,6 +1882,10 @@ static const int DIALOG_CANCEL	= 129;
 		[window setHideMenuBar:YES];
 	}
     
+	BOOL ignoreImageDpi = [defaults boolForKey:@"IgnoreImageDpi"];
+	[fullImageView setIgnoreImageDpi:ignoreImageDpi];
+	[imageView setIgnoreImageDpi:ignoreImageDpi];
+
     NSColor *viewBackGround = [[NSUnarchiver unarchiveObjectWithData:[defaults objectForKey:@"ViewBackGroundColor"]] colorWithAlphaComponent:1];
     [window setBackgroundColor:viewBackGround];
     if (fitScreenMode > 0) {

--- a/CustomImageView.h
+++ b/CustomImageView.h
@@ -13,6 +13,8 @@
 	BOOL didFirst;
 	NSWindow *lensWindow;
 	int maxEnlargement;
+
+	BOOL ignoreImageDpi;
 	//rotate
 	/*0=normal 1=left90 2=left180 3=left270(right90)*/
 	int rotateMode;
@@ -72,6 +74,7 @@
 
 -(void)setUseCalayer:(BOOL)use;
 -(void)setInterpolation:(int)index;
+-(void)setIgnoreImageDpi:(BOOL)ignoreDpi;
 -(void)setImages:(NSImage *)image;
 
 -(BOOL)pageMover;

--- a/CustomImageView.m
+++ b/CustomImageView.m
@@ -1,6 +1,7 @@
 #import "CustomImageView.h"
 #import "NSBezierPath_Adding.h"
 #import "NSAttributedString_Adding.h"
+#import "NSImage_Adding.h"
 #import "AccessoryView.h"
 //#import "QuartzCore/CIFilter.h"
 
@@ -85,6 +86,10 @@
 -(void)setInterpolation:(int)index
 {
 	interpolation = index;
+}
+-(void)setIgnoreImageDpi:(BOOL)ignoreDpi
+{
+	ignoreImageDpi = ignoreDpi;
 }
 -(void)setDragScroll:(NSArray*)array mode:(int)mode
 {
@@ -762,13 +767,14 @@ NSTimeInterval elapsed=0;
 {
     NSMutableDictionary *infodic = [NSMutableDictionary dictionary];
     
+    NSSize imageSize = ignoreImageDpi ? [image pixelsSize] : [image size];
     int widthValue,heightValue;
     if (rotateMode==1||rotateMode==3) {
-        widthValue = [image size].height;
-        heightValue = [image size].width;
+        widthValue = imageSize.height;
+        heightValue = imageSize.width;
     } else {
-        widthValue = [image size].width;
-        heightValue = [image size].height;
+        widthValue = imageSize.width;
+        heightValue = imageSize.height;
     }
 
     float screenWidthValue = NSWidth([[[self window] contentView] frame]);
@@ -949,11 +955,13 @@ NSTimeInterval elapsed=0;
     NSDivideRect (fullscreenRect, &leftRect, &rightRect, fullscreenRect.size.width/2, NSMinXEdge);
 
     
-    int widthValue01 = [image1 size].width;
-    int heightValue01 = [image1 size].height;
+    NSSize image1Size = ignoreImageDpi ? [image1 pixelsSize] : [image1 size];
+    int widthValue01 = image1Size.width;
+    int heightValue01 = image1Size.height;
     
-    int widthValue02 = [image2 size].width;
-    int heightValue02 = [image2 size].height;
+    NSSize image2Size = ignoreImageDpi ? [image2 pixelsSize] : [image2 size];
+    int widthValue02 = image2Size.width;
+    int heightValue02 = image2Size.height;
     
     int widthValue1 = widthValue01;
     int heightValue1 = heightValue01;
@@ -1256,10 +1264,10 @@ NSTimeInterval elapsed=0;
         drawRect2=NSMakeRect(x,center2,widthValue2,heightValue2);
     }
     
-    [infodic setObject:[NSString stringWithFormat:@"%i",widthValue01] forKey:@"widthValue01"];
-    [infodic setObject:[NSString stringWithFormat:@"%i",widthValue02] forKey:@"widthValue02"];
-    [infodic setObject:[NSString stringWithFormat:@"%i",heightValue01] forKey:@"heightValue01"];
-    [infodic setObject:[NSString stringWithFormat:@"%i",heightValue02] forKey:@"heightValue02"];
+    [infodic setObject:[NSString stringWithFormat:@"%i",(int)[image1 size].width] forKey:@"widthValue01"];
+    [infodic setObject:[NSString stringWithFormat:@"%i",(int)[image2 size].width] forKey:@"widthValue02"];
+    [infodic setObject:[NSString stringWithFormat:@"%i",(int)[image1 size].height] forKey:@"heightValue01"];
+    [infodic setObject:[NSString stringWithFormat:@"%i",(int)[image2 size].height] forKey:@"heightValue02"];
     [infodic setObject:NSStringFromRect(drawRect1) forKey:@"drawRect1"];
     [infodic setObject:NSStringFromRect(drawRect2) forKey:@"drawRect2"];
     [infodic setObject:NSStringFromRect(fullscreenRect) forKey:@"fullscreenRect"];
@@ -1395,6 +1403,7 @@ NSTimeInterval elapsed=0;
         [winContentView setLensSize:lensSize];
         [winContentView setRotateMode:rotateMode];
         [winContentView setInterpolation:interpolation];
+        [winContentView setIgnoreImageDpi:ignoreImageDpi];
         [winContentView setParentFrame:[self frame]];
         [winContentView display];
         

--- a/FullImageView.h
+++ b/FullImageView.h
@@ -6,7 +6,9 @@
 @interface FullImageView : NSImageView {
 	NSImage*image;
 	NSPoint oldPoint;
+	BOOL ignoreImageDpi;
 }
+- (void)setIgnoreImageDpi:(BOOL)ignoreDpi;
 - (void)imageScroll:(NSPoint)point;
 - (void)scrollToTop;
 - (void)scrollToLast;

--- a/FullImageView.m
+++ b/FullImageView.m
@@ -4,6 +4,7 @@
 //
 
 #import "FullImageView.h"
+#import "NSImage_Adding.h"
 
 
 @implementation FullImageView
@@ -13,8 +14,9 @@
 
 - (void)setImage:(NSImage *)im
 {
-	[self setFrameSize:[im size]];
-	//[self setFrame:NSMakeRect(0,0,[image size].width,[image size].height)];
+	NSSize imageSize = ignoreImageDpi ? [im pixelsSize] : [im size];
+	[self setFrameSize:imageSize];
+	//[self setFrame:NSMakeRect(0,0,imageSize.width,imageSize.height)];
 	[super setImage:im];
 	/*
 	[image autorelease];
@@ -22,9 +24,19 @@
 	 [[image bestRepresentationForDevice:nil] drawInRect:[self bounds]];*/
 	 /*
 	[image drawInRect:[self bounds]
-			  fromRect:NSMakeRect(0,0,[image size].width,[image size].height)
+			  fromRect:NSMakeRect(0,0,imageSize.width,imageSize.height)
 			 operation:NSCompositeSourceOver fraction:1.0];*/
+}
 
+- (void)drawRect:(NSRect)dirtyRect {
+	//[super drawRect:dirtyRect];
+	NSImage *image = [self image];
+	[image drawInRect:[self bounds]
+			 fromRect:NSMakeRect(0,0,[image size].width,[image size].height)
+			operation:NSCompositingOperationSourceOver
+			 fraction:1.0
+	   respectFlipped:self.isFlipped
+				hints:nil];
 }
 
 -(void)mouseDown:(NSEvent *)event
@@ -66,11 +78,12 @@
 		newY = [self bounds].size.height - [clipView documentVisibleRect].size.height;
 	}
 	
-	if ([[self image] size].width < [clipView documentVisibleRect].size.width) {
+	NSSize imageSize = ignoreImageDpi ? [[self image] pixelsSize] : [[self image] size];
+	if (imageSize.width < [clipView documentVisibleRect].size.width) {
 		newX = 0;
 	}
 	/*
-	if ([[self image] size].height == [self bounds].size.height) {
+	if (imageSize.height == [self bounds].size.height) {
 		newY = 0;
 	}
 	*/
@@ -86,6 +99,11 @@
 //	[[self superview] autoscroll:event];
 //	NSLog(@"Current mouse point:%@", NSStringFromPoint([event locationInWindow]));
 //	[self setNeedsDisplay:YES];
+}
+
+- (void)setIgnoreImageDpi:(BOOL)ignoreDpi
+{
+	ignoreImageDpi = ignoreDpi;
 }
 
 - (void)imageScroll:(NSPoint)point
@@ -112,7 +130,8 @@
 	if (newY > [self bounds].size.height - [clipView documentVisibleRect].size.height) {
 		newY = [self bounds].size.height - [clipView documentVisibleRect].size.height;
 	}
-	if ([[self image] size].width < [clipView documentVisibleRect].size.width) {
+	NSSize imageSize = ignoreImageDpi ? [[self image] pixelsSize] : [[self image] size];
+	if (imageSize.width < [clipView documentVisibleRect].size.width) {
 		newX = 0;
 	}
 	NSPoint newPoint = NSMakePoint(newX,newY);

--- a/LoupeView.h
+++ b/LoupeView.h
@@ -24,6 +24,8 @@
     
     NSRect parentFrame;
     
+    BOOL ignoreImageDpi;
+
 }
 
 -(void)setTargetController:(Controller *)c;
@@ -34,6 +36,7 @@
 -(void)setLensSize:(int)ls;
 -(void)setRotateMode:(int)rm;
 -(void)setInterpolation:(int)index;
+-(void)setIgnoreImageDpi:(BOOL)ignoreImageDpi;
 -(void)setParentFrame:(NSRect)pf;
 
 @end

--- a/LoupeView.m
+++ b/LoupeView.m
@@ -6,6 +6,7 @@
 //
 
 #import "LoupeView.h"
+#import "NSImage_Adding.h"
 
 @implementation LoupeView
 
@@ -40,6 +41,10 @@
 -(void)setInterpolation:(int)index
 {
     interpolation = index;
+}
+-(void)setIgnoreImageDpi:(BOOL)ignoreDpi
+{
+    ignoreImageDpi = ignoreDpi;
 }
 -(void)setParentFrame:(NSRect)pf
 {
@@ -80,8 +85,9 @@
             NSAffineTransform *transform = [NSAffineTransform transform];
             NSRect tempRect = fRect;
             image = [targetController image1];
-            widthValue = [image size].width;
-            heightValue = [image size].height;
+            NSSize imageSize = ignoreImageDpi ? [image pixelsSize] : [image size];
+            widthValue = imageSize.width;
+            heightValue = imageSize.height;
             
             if (rotateMode==1) {
                 [transform translateXBy:lensSize yBy:0];
@@ -101,12 +107,12 @@
                 drawPoint.x = (parentFrame.size.height-mPoint.y);
                 drawPoint.y = mPoint.x;
             }
-            float x = [image size].width/tempRect.size.width;
+            float x = imageSize.width/tempRect.size.width;
             iPoint.x = (int)((drawPoint.x - tempRect.origin.x)*lensRate*x);
             iPoint.y = (int)((drawPoint.y - tempRect.origin.y)*lensRate*x);
             [transform concat];
             [image drawInRect:NSMakeRect((iPoint.x*-1+lensSize/2),(iPoint.y*-1+lensSize/2),widthValue*lensRate,heightValue*lensRate)
-                    fromRect:NSMakeRect(0,0,widthValue,heightValue)
+                     fromRect:NSMakeRect(0,0,[image size].width,[image size].height)
                     operation:NSCompositeSourceOver fraction:1.0];
             [transform invert];
             [transform concat];
@@ -146,15 +152,16 @@
                 } else {
                     image = [targetController image2];
                 }
-                widthValue = [image size].width;
-                heightValue = [image size].height;
+                NSSize imageSize = ignoreImageDpi ? [image pixelsSize] : [image size];
+                widthValue = imageSize.width;
+                heightValue = imageSize.height;
                 
                 /*
-                float x = [image size].width/fTempRect.size.width;
+                float x = imageSize.width/fTempRect.size.width;
                 iPoint.x = (int)((drawPoint.x - fTempRect.origin.x)*x);
                 iPoint.y = (int)((drawPoint.y - fTempRect.origin.y)*x);
                 */
-                float x = [image size].width/fTempRect.size.width;
+                float x = imageSize.width/fTempRect.size.width;
                 iPoint.x = (int)((drawPoint.x - fTempRect.origin.x)*lensRate*x);
                 iPoint.y = (int)((drawPoint.y - fTempRect.origin.y)*lensRate*x);
                 if (NSIntersectsRect(NSMakeRect(mPoint.x-lensSize/2,mPoint.y-lensSize/2,lensSize,lensSize),sRect)) {
@@ -164,14 +171,15 @@
                     } else {
                         sImage = [targetController image1];
                     }
-                    NSInteger sWidthValue = [sImage size].width;
-                    NSInteger sHeightValue = [sImage size].height;
-                    float sx = [sImage size].width/sTempRect.size.width;
+                    NSSize sImageSize = ignoreImageDpi ? [sImage pixelsSize] : [sImage size];
+                    NSInteger sWidthValue = sImageSize.width;
+                    NSInteger sHeightValue = sImageSize.height;
+                    float sx = sImageSize.width/sTempRect.size.width;
                     NSPoint sPoint;
                     sPoint.x = (int)((drawPoint.x - sTempRect.origin.x)*lensRate*x);
                     sPoint.y = (int)((drawPoint.y - sTempRect.origin.y)*lensRate*x);
                     [sImage drawInRect:NSMakeRect((sPoint.x*-1+lensSize/2),(sPoint.y*-1+lensSize/2),sWidthValue*lensRate,sHeightValue*lensRate)
-                            fromRect:NSMakeRect(0,0,sWidthValue,sHeightValue)
+                              fromRect:NSMakeRect(0,0,[sImage size].width,[sImage size].height)
                             operation:NSCompositeSourceOver fraction:1.0];
                 }
             } else /*if (NSPointInRect(mPoint,sRect))*/ {
@@ -180,15 +188,16 @@
                 } else {
                     image = [targetController image1];
                 }
-                widthValue = [image size].width;
-                heightValue = [image size].height;
+                NSSize imageSize = ignoreImageDpi ? [image pixelsSize] : [image size];
+                widthValue = imageSize.width;
+                heightValue = imageSize.height;
                 
                 /*
-                float x = [image size].width/sTempRect.size.width;
+                float x = imageSize.width/sTempRect.size.width;
                 iPoint.x = (int)((drawPoint.x - sTempRect.origin.x)*x);
                 iPoint.y = (int)((drawPoint.y - sTempRect.origin.y)*x);
                 */
-                float x = [image size].width/sTempRect.size.width;
+                float x = imageSize.width/sTempRect.size.width;
                 iPoint.x = (int)((drawPoint.x - sTempRect.origin.x)*lensRate*x);
                 iPoint.y = (int)((drawPoint.y - sTempRect.origin.y)*lensRate*x);
                 if (NSIntersectsRect(NSMakeRect(mPoint.x-lensSize/2,mPoint.y-lensSize/2,lensSize,lensSize),fRect)) {
@@ -198,19 +207,20 @@
                     } else {
                         sImage = [targetController image2];
                     }
-                    NSInteger sWidthValue = [sImage size].width;
-                    NSInteger sHeightValue = [sImage size].height;
-                    float sx = [sImage size].width/fTempRect.size.width;
+                    NSSize sImageSize = ignoreImageDpi ? [sImage pixelsSize] : [sImage size];
+                    NSInteger sWidthValue = sImageSize.width;
+                    NSInteger sHeightValue = sImageSize.height;
+                    float sx = sImageSize.width/fTempRect.size.width;
                     NSPoint sPoint;
                     sPoint.x = (int)((drawPoint.x - fTempRect.origin.x)*lensRate*x);
                     sPoint.y = (int)((drawPoint.y - fTempRect.origin.y)*lensRate*x);
                     [sImage drawInRect:NSMakeRect((sPoint.x*-1+lensSize/2),(sPoint.y*-1+lensSize/2),sWidthValue*lensRate,sHeightValue*lensRate)
-                            fromRect:NSMakeRect(0,0,sWidthValue,sHeightValue)
+                              fromRect:NSMakeRect(0,0,[sImage size].width,[sImage size].height)
                             operation:NSCompositeSourceOver fraction:1.0];
                 }
             }
             [image drawInRect:NSMakeRect((iPoint.x*-1+lensSize/2),(iPoint.y*-1+lensSize/2),widthValue*lensRate,heightValue*lensRate)
-                    fromRect:NSMakeRect(0,0,widthValue,heightValue)
+                     fromRect:NSMakeRect(0,0,[image size].width,[image size].height)
                     operation:NSCompositeSourceOver fraction:1.0];
             [transform invert];
             [transform concat];

--- a/NSImage_Adding.h
+++ b/NSImage_Adding.h
@@ -1,0 +1,14 @@
+//
+//  NSImage_Adding.h
+//  cooViewer
+//
+
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSImage (Adding)
+- (NSSize)pixelsSize;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/NSImage_Adding.m
+++ b/NSImage_Adding.m
@@ -1,0 +1,15 @@
+//
+//  NSImage_Adding.m
+//  cooViewer
+//
+
+#import "NSImage_Adding.h"
+
+@implementation NSImage (Adding)
+
+- (NSSize)pixelsSize {
+    NSImageRep *imagerep = [[self representations] firstObject];
+    return NSMakeSize([imagerep pixelsWide], [imagerep pixelsHigh]);
+}
+
+@end

--- a/PreferenceController.h
+++ b/PreferenceController.h
@@ -111,6 +111,7 @@
     IBOutlet id changeCurrentFolderPopUpButton;
     
     IBOutlet id useCalayerCheck;
+    IBOutlet id ignoreDpiCheck;
 }
 + (NSArray*)defaultKeyArray;
 + (NSArray*)defaultKeyArrayMode2;

--- a/PreferenceController.m
+++ b/PreferenceController.m
@@ -1034,6 +1034,11 @@ static const int DIALOG_CANCEL	= 129;
 	} else {
 		[showThumbnailCheck setState:NSOffState];
 	}
+	if ([defaults boolForKey:@"IgnoreImageDpi"]) {
+		[ignoreDpiCheck setState:NSControlStateValueOn];
+	} else {
+		[ignoreDpiCheck setState:NSControlStateValueOff];
+	}
 	
 	/*history*/
 	if ([defaults boolForKey:@"AlwaysRememberLastPage"]) {
@@ -1553,6 +1558,11 @@ static const int DIALOG_CANCEL	= 129;
 			[defaults setBool:YES forKey:@"ShowThumbnailWhenOpen"];
 		} else {
 			[defaults setBool:NO forKey:@"ShowThumbnailWhenOpen"];
+		}
+		if ([ignoreDpiCheck state]==NSControlStateValueOn) {
+			[defaults setBool:YES forKey:@"IgnoreImageDpi"];
+		} else {
+			[defaults setBool:NO forKey:@"IgnoreImageDpi"];
 		}
 		
 		if ([alwaysRememberLastCheck state]==NSOnState) {

--- a/cooViewer.xcodeproj/project.pbxproj
+++ b/cooViewer.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B13173F24CF1B0400A17553 /* NSImage_Adding.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B13173D24CF1B0400A17553 /* NSImage_Adding.h */; };
+		0B13174024CF1B0400A17553 /* NSImage_Adding.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B13173E24CF1B0400A17553 /* NSImage_Adding.m */; };
 		372911581316C60C0040B910 /* empty.png in Resources */ = {isa = PBXBuildFile; fileRef = 372911571316C60C0040B910 /* empty.png */; };
 		373D3539130F075E0037F8DD /* GlobalKeyboardDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 373D3537130F075E0037F8DD /* GlobalKeyboardDevice.h */; };
 		373D353A130F075E0037F8DD /* GlobalKeyboardDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 373D3538130F075E0037F8DD /* GlobalKeyboardDevice.m */; };
@@ -137,6 +139,8 @@
 
 /* Begin PBXFileReference section */
 		089C165DFE840E0CC02AAC07 /* InfoPlist.strings */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; path = InfoPlist.strings; sourceTree = "<group>"; };
+		0B13173D24CF1B0400A17553 /* NSImage_Adding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSImage_Adding.h; sourceTree = "<group>"; };
+		0B13173E24CF1B0400A17553 /* NSImage_Adding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSImage_Adding.m; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
@@ -572,6 +576,8 @@
 			children = (
 				761C25AB0D5F4D9F0038687B /* NSBezierPath_Adding.h */,
 				761C25AC0D5F4D9F0038687B /* NSBezierPath_Adding.m */,
+				0B13173D24CF1B0400A17553 /* NSImage_Adding.h */,
+				0B13173E24CF1B0400A17553 /* NSImage_Adding.m */,
 				76705AE40885785900FEF4E2 /* NSString_Compare.h */,
 				76705AE50885785900FEF4E2 /* NSString_Compare.m */,
 			);
@@ -609,6 +615,7 @@
 				76344C0A09595C74003761DA /* COImageLoader.h in Headers */,
 				76B88ED1097FC1D8006DDB12 /* COPDFImage.h in Headers */,
 				7655CDCF09806A8F00465FD1 /* COPDFImageRep.h in Headers */,
+				0B13173F24CF1B0400A17553 /* NSImage_Adding.h in Headers */,
 				766DE03809936CF5004DD915 /* COColorPopUpButton.h in Headers */,
 				76B85F8D099BB20B0077A211 /* NSDictionary_Adding.h in Headers */,
 				A31C5A9923CA3D6300DD4E70 /* FilterPanelController.h in Headers */,
@@ -762,6 +769,7 @@
 				76D5AA450D69E41C0057EF7A /* RemoteControl.m in Sources */,
 				76D5AA470D69E41C0057EF7A /* HIDRemoteControlDevice.m in Sources */,
 				76D5AA520D69E42D0057EF7A /* AppleRemote.m in Sources */,
+				0B13174024CF1B0400A17553 /* NSImage_Adding.m in Sources */,
 				76D5AA540D69E42D0057EF7A /* KeyspanFrontRowControl.m in Sources */,
 				76E56F530D74647400128802 /* MultiClickRemoteBehavior.m in Sources */,
 				373D353A130F075E0037F8DD /* GlobalKeyboardDevice.m in Sources */,

--- a/ja.lproj/MainMenu.strings
+++ b/ja.lproj/MainMenu.strings
@@ -1477,3 +1477,5 @@
 /* Class = "NSMenuItem"; title = "Filter"; ObjectID = "usF-pH-ycg"; */
 "usF-pH-ycg.title" = "フィルター";
 
+/* Class = "NSButtonCell"; title = "Ignore image DPI:"; ObjectID = "uSp-vs-7XI"; */
+"uSp-vs-7XI.title" = "画像のDPIを無視する";


### PR DESCRIPTION
### 変更内容
プレビュー.appと同じように原寸表示時に画像のDPIを無視できるようにしました。
環境設定の高度な設定に"画像のDPIを無視する"というチェックボックスを追加しています。

チェックを入れると、以下の表示で画像のDPIを無視したサイズを使用します。
- FITモード=画面に合わせない
- ルーペ表示
- 右/左の画像を実際のサイズで表示

### 懸念点
Retinaのmacしか持っていないので、非Retinaだと正常に動くかわからないです…。
一応、"低解像度で開く"にチェックを入れた場合は正常に動くことは確認済みです。

"右/左の画像を実際のサイズで表示"のとき、高解像度の画像だとカクつくかもしれません。
ここでもCALayerを使うようにすれば解消するかもしれませんが、とりあえずそのままにしています。