### PR TITLE
単ページ・見開きのデフォルト値が無視されることがあるのを修正

### DIFF
--- a/Controller.m
+++ b/Controller.m
@@ -2968,6 +2968,7 @@ static const int DIALOG_CANCEL	= 129;
 		currentBookPath = nil;
 		currentBookName = nil;
 		currentBookAlias = nil;
+		[currentBookSetting removeAllObjects];
 		[imageMutableArray removeAllObjects];
 		[bookmarkArray removeAllObjects];
 		[marksArray removeAllObjects];


### PR DESCRIPTION
挙動の再現方法

環境設定 → 「一般」タブ
[ ] 単ページ
[x] 変更された本の設定を記憶する

上記のような設定で、

1. 単ページに変更した本を開く
2. Cmd-W/esc で閉じる
3. 本の設定をしていない別の本を開くと単ページで開かれてしまう (デフォルトの見開きにならない)

Cmd-W/esc で閉じずに別の本を開いた場合はデフォルトの見開きになる
